### PR TITLE
make node-gyp optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
+  - "node"
 after_script: npm run coverage

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var _ = require('lodash')
 var chalk = require('chalk')
 var cheerio = require('cheerio')
-var Highlights = require('highlights')
+var Highlights = require('atom-highlightsjs')
 var highlighter = new Highlights()
 
 var languages = [

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
   },
   "homepage": "https://github.com/bcoe/hl#readme",
   "dependencies": {
+    "atom-highlightsjs": "^1.3.0",
     "atom-language-nginx": "^0.4.0",
     "chalk": "^1.1.1",
     "cheerio": "^0.19.0",
-    "highlights": "^1.3.0",
     "language-dart": "^0.1.1",
     "language-erlang": "^2.0.0",
     "language-glsl": "^2.0.1",

--- a/test/fixtures/test.md
+++ b/test/fixtures/test.md
@@ -1,0 +1,11 @@
+# hl
+
+[![Build Status](https://travis-ci.org/bcoe/hl.svg)](https://travis-ci.org/bcoe/hl)
+[![Coverage Status](https://coveralls.io/repos/bcoe/hl/badge.svg?branch=master)](https://coveralls.io/r/bcoe/hl?branch=master)
+[![NPM version](https://img.shields.io/npm/v/hl.svg)](https://www.npmjs.com/package/hl)
+
+Use Atom's syntax-highlighter from the command line.
+
+```sh
+npm install hl -g
+```


### PR DESCRIPTION
Uses [forked version](https://www.npmjs.com/package/atom-highlightsjs) of highlights, which makes compiling optional.
