### PR TITLE
adds support for Makefile highlighting

### DIFF
--- a/bin/hl.js
+++ b/bin/hl.js
@@ -18,8 +18,7 @@ var yargs = require('yargs')
   })
   .option('e', {
     alias: 'extension',
-    describe: 'when using unix pipes an extension hint must be provided',
-    default: 'js'
+    describe: 'when using unix pipes an extension hint must be provided'
   })
   .help('help')
   .alias('h', 'help')
@@ -47,13 +46,14 @@ if (argv.pipe) {
     code += out
   })
   process.stdin.on('end', function () {
-    output(code, argv.extension)
+    var extension = argv.extension ? argv.extension : 'js'
+    output(code, extension)
     process.exit(0)
   })
 } else if (argv._.length) {
   var file = argv._[0]
-  var extension = path.extname(file)
-  output(fs.readFileSync(file, 'utf-8'), extension)
+  var extension = argv.extension || path.extname(file)
+  output(fs.readFileSync(file, 'utf-8'), extension || path.basename(file))
 }
 
 function output (code, extension) {

--- a/index.js
+++ b/index.js
@@ -78,10 +78,6 @@ hl.map = function (extension) {
   }
 }
 
-hl.mapFile = function (file) {
-  return 'source' + (fileMappings[file.toLowerCase()] || '.unknown')
-}
-
 hl.chalkify = function (codeHtml) {
   var $ = cheerio.load(codeHtml)
   var lines = []

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ function hlCode (code, extension) {
   })
 }
 
-var mappings = {
+var extensionMappings = {
   '.rb': '.ruby',
   '.h': '.objc',
   '.m': '.objc',
@@ -65,9 +65,21 @@ var mappings = {
   '.py': '.python'
 }
 
+var fileMappings = {
+  'makefile': '.makefile'
+}
+
 hl.map = function (extension) {
-  if (extension.indexOf('.') === -1) extension = '.' + extension
-  return 'source' + (mappings[extension] || extension)
+  if (fileMappings[extension.toLowerCase()]) {
+    return 'source' + fileMappings[extension.toLowerCase()]
+  } else {
+    if (extension.indexOf('.') === -1) extension = '.' + extension
+    return 'source' + (extensionMappings[extension] || extension)
+  }
+}
+
+hl.mapFile = function (file) {
+  return 'source' + (fileMappings[file.toLowerCase()] || '.unknown')
 }
 
 hl.chalkify = function (codeHtml) {

--- a/test/fixtures/makefile
+++ b/test/fixtures/makefile
@@ -1,0 +1,24 @@
+SUBMISSIONS = $(SRC) $(HEADER) Makefile README
+
+all: $(TESTEXE)
+
+depend:
+        makedepend -Y $(SRC)
+clean:
+        rm -f $(OBJ) $(EXE)
+
+testdeq: testdeq.o $(LIBOBJ)
+
+testperf: testperf.o $(LIBOBJ)
+
+submit:
+        rm -rf Submit
+        mkdir Submit
+        cp $(SUBMISSIONS) Submit
+
+archive:
+        rm -rf deque deque.tar.gz
+        mkdir deque
+        cp $(SUBMISSIONS) deque
+        tar -cf deque.tar deque
+        gzip deque.tar

--- a/test/hl.js
+++ b/test/hl.js
@@ -10,6 +10,11 @@ describe('hl', function () {
       assert.equal(hl.map('.rb'), 'source.ruby')
       assert.equal(hl.map('.json'), 'source.json')
     })
+
+    it('highlights based on common filnames if no extension is found', function () {
+      assert.equal(hl.map('makefile'), 'source.makefile')
+      assert.equal(hl.map('Makefile'), 'source.makefile')
+    })
   })
 
   describe('chalkify', function () {


### PR DESCRIPTION
If a file does not have an extension, e.g., `Makefile`, hl will now perform a lookup based on common filenames.

Specifying an extension will now also work when not running in pipe mode, e.g.,

`hl MyMakefile --extension=makefile`

fixes #7, CC: @abh1nav
